### PR TITLE
Use env var for secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ CONCOURSE_URL ?= http://concourse.suse.de/
 GITHUB_ID ?= c29a4757ff0e43c25610
 GITHUB_TEAM ?= 'SUSE/Team Alfred'
 CONCOURSE_SECRETS_FILE ?= ../cloudfoundry/secure/concourse-secrets.yml.gpg
-TMP_SECRETS_FILE := $(shell mktemp -t tmp-concourseXXXXXX)
 
 all: pipeline-master pipeline-check
 
@@ -16,8 +15,7 @@ login-vancouver:
 login-sandbox:
 	fly -t sandbox login  --concourse-url http://192.168.100.4:8080/
 
-pipeline-%:
-	gpg --decrypt --batch --no-tty ${CONCOURSE_SECRETS_FILE} > ${TMP_SECRETS_FILE} 2> /dev/null
-	yes | fly -t ${TARGET} set-pipeline -c bosh-linux-stemcell-builder-$*.yml -p stemcells-$* -l ${TMP_SECRETS_FILE}
+pipeline-%: ${CONCOURSE_SECRETS_FILE}
+	# Explicitly call bash here to get process substitution
+	yes | bash -c "fly -t ${TARGET} set-pipeline -c bosh-linux-stemcell-builder-$*.yml -p stemcells-$* -l <(gpg --decrypt --batch --no-tty ${CONCOURSE_SECRETS_FILE})"
 	fly -t ${TARGET} unpause-pipeline -p stemcells-$*
-	rm -f ${TMP_SECRETS_FILE}

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ login-sandbox:
 	fly -t sandbox login  --concourse-url http://192.168.100.4:8080/
 
 pipeline-%:
-	gpg --decrypt --batch --no-tty ${CONCOURSE_SECRETS_FILE} > ${TMP_SECRETS_FILE}
+	gpg --decrypt --batch --no-tty ${CONCOURSE_SECRETS_FILE} > ${TMP_SECRETS_FILE} 2> /dev/null
 	yes | fly -t ${TARGET} set-pipeline -c bosh-linux-stemcell-builder-$*.yml -p stemcells-$* -l ${TMP_SECRETS_FILE}
 	fly -t ${TARGET} unpause-pipeline -p stemcells-$*
 	rm -f ${TMP_SECRETS_FILE}

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ login-sandbox:
 	fly -t sandbox login  --concourse-url http://192.168.100.4:8080/
 
 pipeline-%: ${CONCOURSE_SECRETS_FILE}
-	# Explicitly call bash here to get process substitution
+	# Explicitly call bash here to get process substitution, otherwise make
+	# runs the shell in a mode that doesn't support <(...)
 	yes | bash -c "fly -t ${TARGET} set-pipeline -c bosh-linux-stemcell-builder-$*.yml -p stemcells-$* -l <(gpg --decrypt --batch --no-tty ${CONCOURSE_SECRETS_FILE})"
 	fly -t ${TARGET} unpause-pipeline -p stemcells-$*


### PR DESCRIPTION
We're standardizing the secrets location across all of the pipelines. This means the `pipeline-*` targets will prompt for a password now.

Related:
https://github.com/SUSE/fissile-stemcell-openSUSE-ci/pull/1