### PR TITLE
Build new fissile stemcells when new configgin versions are published

### DIFF
--- a/bosh-linux-stemcell-builder-check.yml
+++ b/bosh-linux-stemcell-builder-check.yml
@@ -8,6 +8,10 @@ resource_types:
     type: docker-image
     source:
       repository: splatform/concourse-github-status
+  - name: rubygems
+    type: docker-image
+    source:
+      repository: resource/rubygems
 
 jobs:
   #
@@ -119,6 +123,8 @@ jobs:
         - get: semver.os-image-ubuntu
           passed:
             - build-os-image-ubuntu-trusty
+        - get: rubygems.configgin
+          trigger: true
       - task: setup-ubuntu-stemcell-versions
         file: ci/tasks/setup-ubuntu-stemcell-versions.yml
         input_mapping: { src: git.fissile-stemcell-ubuntu }
@@ -217,6 +223,8 @@ jobs:
         - get: semver.os-image-opensuse
           passed:
             - build-os-image-opensuse-leap
+        - get: rubygems.configgin
+          trigger: true
       - task: setup-opensuse-stemcell-versions
         file: ci/tasks/setup-opensuse-stemcell-versions.yml
         input_mapping: { src: git.fissile-stemcell-opensuse }
@@ -358,6 +366,12 @@ resources:
     source:
       uri: https://github.com/cloudfoundry-community/fissile-stemcell-ubuntu.git
       branch: trusty
+
+  - name: rubygems.configgin
+    type: rubygems
+    source:
+      gem: configgin
+      api_key: {{rubygems-apikey}}
 
   - name: semver.os-image-opensuse
     type: semver

--- a/bosh-linux-stemcell-builder-master.yml
+++ b/bosh-linux-stemcell-builder-master.yml
@@ -1,4 +1,10 @@
 ---
+resource_types:
+  - name: rubygems
+    type: docker-image
+    source:
+      repository: resource/rubygems
+
 jobs:
   #
   # Pipeline won't automatically build if src changes, need to
@@ -66,6 +72,8 @@ jobs:
         - get: semver.os-image-ubuntu
           passed:
             - build-os-image-ubuntu-trusty
+        - get: rubygems.configgin
+          trigger: true
       - task: setup-ubuntu-stemcell-versions
         file: ci/tasks/setup-ubuntu-stemcell-versions.yml
         input_mapping:
@@ -128,6 +136,8 @@ jobs:
         - get: semver.os-image-opensuse
           passed:
             - build-os-image-opensuse-leap
+        - get: rubygems.configgin
+          trigger: true
       - task: setup-opensuse-stemcell-versions
         file: ci/tasks/setup-opensuse-stemcell-versions.yml
         input_mapping:
@@ -715,6 +725,12 @@ resources:
     source:
       uri: https://github.com/cloudfoundry-community/fissile-stemcell-ubuntu.git
       branch: trusty
+
+  - name: rubygems.configgin
+    type: rubygems
+    source:
+      gem: configgin
+      api_key: {{rubygems-apikey}}
 
   - name: semver.os-image-opensuse
     type: semver


### PR DESCRIPTION
This makes us build new fissile stemcells whenever new configgin gems are published.  This ensures that we have new stemcells to use, and removes a manual step (so that we don't end up forgetting to build one of the two stemcells).

I have no idea what the state of our pipelines are in (the master pipeline seems to match the contents of this branch, but the check pipeline seems to be missing‽), so I need a review for this to hand-hold me through deploying things…