### PR TITLE
Revert unifying of openSUSE and SLE sources

### DIFF
--- a/bosh-linux-stemcell-builder-master.yml
+++ b/bosh-linux-stemcell-builder-master.yml
@@ -712,8 +712,8 @@ resources:
   - name: git.fissile-stemcell-sles
     type: git
     source:
-      uri: https://github.com/SUSE/fissile-stemcell-openSUSE.git
-      branch: 42.2
+      uri: https://github.com/SUSE/fissile-stemcell-sle.git
+      branch: master
 
   - name: git.fissile-stemcell-ubuntu
     type: git


### PR DESCRIPTION
This PR reverts the unifying of openSUSE and SLE sources introduced by https://github.com/SUSE/bosh-linux-stemcell-builder-ci/pull/3. The reason  is that the SLE fissile stemcell gets a wrong tag (42.2... instead of 12SP3...), because the tag is extracted from git data (branch, git tag etc.).

https://github.com/SUSE/fissile-stemcell-SLE/pull/1 have to be merged before this PR.

Jonathan

