### PR TITLE
push sle fissile docker image tag to s3

### DIFF
--- a/fissile/pipeline.yml
+++ b/fissile/pipeline.yml
@@ -150,6 +150,10 @@ jobs:
           tag_as_latest: ((tag-as-latest))
         get_params:
           skip_download: true
+      - put: s3.fissile-stemcell-sle-12-docker-imagename
+        params:
+          file: versioned-fissile-stemcell-sles/VERSION
+
 
 resources:
   - name: ci
@@ -287,3 +291,12 @@ resources:
       versioned_file: fissile-stemcell-versions/fissile-stemcell-opensuse-version-develop
       access_key_id: {{stemcell-version-aws-access-key}}
       secret_access_key: {{stemcell-version-aws-secret-key}}
+
+  - name: s3.fissile-stemcell-sle-12-docker-imagename
+    type: s3
+    source:
+      bucket: {{sles-osimage-aws-bucket}}
+      versioned_file: VERSION.txt
+      access_key_id: {{sles-stemcell-aws-access-key}}
+      secret_access_key: {{sles-stemcell-aws-secret-key}}
+      region_name: {{sles-osimage-aws-region}}


### PR DESCRIPTION
This PR will create a file on the sle s3 bucket called VERSION.txt containing the currently used tag for the  current `fissile-stemcell-sle12` docker image. This is needed for the `submit-sources-to-obs`pipeline.